### PR TITLE
[pi-k-three-s] Update to support tunnels to Pi cluster

### DIFF
--- a/porter/pi-k-three-s/DEPLOYMENT.md
+++ b/porter/pi-k-three-s/DEPLOYMENT.md
@@ -23,7 +23,7 @@ For detailed instructions on deploying from Azure, including how to setup the se
 For detailed instructions on deploying from Cloud Shell, including how to setup the Cloud Shell environment, see [Consuming: Deploy from Cloud Shell](../../docs/consuming.md#deploy-from-cloud-shell)
 
 
-```porter install --tag cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-177 -d azure```
+```porter install --tag cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-179 -d azure```
 
 
 ## Parameters and Credentials

--- a/porter/pi-k-three-s/DEPLOYMENT.md
+++ b/porter/pi-k-three-s/DEPLOYMENT.md
@@ -23,7 +23,7 @@ For detailed instructions on deploying from Azure, including how to setup the se
 For detailed instructions on deploying from Cloud Shell, including how to setup the Cloud Shell environment, see [Consuming: Deploy from Cloud Shell](../../docs/consuming.md#deploy-from-cloud-shell)
 
 
-```porter install --tag cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-174 -d azure```
+```porter install --tag cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-177 -d azure```
 
 
 ## Parameters and Credentials

--- a/porter/pi-k-three-s/INSTRUCTIONS.md
+++ b/porter/pi-k-three-s/INSTRUCTIONS.md
@@ -57,7 +57,7 @@ scp <path-to-public-key> pi@<hostname>:~\.ssh\authorized_keys
 
 Once the Raspberry Pi devices are setup according the instructions above, the bundle can be installed.
 
-It's important to note that unless the Raspberry Pi devices are accessible via the Internet, then you will have to run this bundle locally on a device connected to the same network as the Pis, and use the Docker driver for Porter (rather than the Azure driver).
+It's important to note that unless the Raspberry Pi devices are accessible via the Internet (see [Tunnelling to Pis](#tunneling-to-pis) below), then you will have to run this bundle locally on a device connected to the same network as the Pis, and use the Docker driver for Porter (rather than the Azure driver).
 
 You will need to have Porter and Docker installed locally, then you can use the following commands:
 
@@ -68,3 +68,18 @@ porter install --tag cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:lates
 ```
 
 See [Parameters and Credentials](#parameters-and-credentials) below for more details on the parameters.
+
+## Tunneling to Pis
+
+If you want to use the 'Deploy from Azure button' or 'Deploy from Cloud Shell' options below, you need to ensure that the master Raspberry Pi in your cluster is accessible from the Internet. The bundle uses the master Pi as a jumpbox to the worker Pi nodes, so only the master needs to be exposed.
+
+Specifically, port 22 needs to be accessible for SSH and port 6443 for accessing the kubernetes API.
+
+One option is to use a tunneling service, such as [PiTunnel](https://www.pitunnel.com/) or [ngrok](https://ngrok.com/), to create tunnels from the Pi for the 2 ports. If using PiTunnel, the steps would be as follows:
+
+1. Create a PiTunnel account at [PiTunnel.com](https://www.pitunnel.com/)
+2. Upgrade to the Standard account (this enables static port numbers for tunnerls; this is necessary as the Pi will reboot as part of the installation, causing the port number to change if static port numbers aren't enabled)
+3. Install PiTunnel on the master Pi - `curl https://pitunnel.com/install/b5KgouUVv | sudo python`
+4. Create a (persistent) tunnel for SSH - `pitunnel --port=22 --name=ssh --persist`
+5. Create a (persistent) tunnel for kubernetes API - `pitunnel --port=6443 --name=k8s --http --persist`
+6. Go to the [PiTunnel dashboard](https://www.pitunnel.com/active) to find the tunnel URLs/ports

--- a/porter/pi-k-three-s/README.md
+++ b/porter/pi-k-three-s/README.md
@@ -59,7 +59,7 @@ scp <path-to-public-key> pi@<hostname>:~\.ssh\authorized_keys
 
 Once the Raspberry Pi devices are setup according the instructions above, the bundle can be installed.
 
-It's important to note that unless the Raspberry Pi devices are accessible via the Internet, then you will have to run this bundle locally on a device connected to the same network as the Pis, and use the Docker driver for Porter (rather than the Azure driver).
+It's important to note that unless the Raspberry Pi devices are accessible via the Internet (see [Tunnelling to Pis](#tunneling-to-pis) below), then you will have to run this bundle locally on a device connected to the same network as the Pis, and use the Docker driver for Porter (rather than the Azure driver).
 
 You will need to have Porter and Docker installed locally, then you can use the following commands:
 
@@ -70,6 +70,21 @@ porter install --tag cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:lates
 ```
 
 See [Parameters and Credentials](#parameters-and-credentials) below for more details on the parameters.
+
+## Tunneling to Pis
+
+If you want to use the 'Deploy from Azure button' or 'Deploy from Cloud Shell' options below, you need to ensure that the master Raspberry Pi in your cluster is accessible from the Internet. The bundle uses the master Pi as a jumpbox to the worker Pi nodes, so only the master needs to be exposed.
+
+Specifically, port 22 needs to be accessible for SSH and port 6443 for accessing the kubernetes API.
+
+One option is to use a tunneling service, such as [PiTunnel](https://www.pitunnel.com/) or [ngrok](https://ngrok.com/), to create tunnels from the Pi for the 2 ports. If using PiTunnel, the steps would be as follows:
+
+1. Create a PiTunnel account at [PiTunnel.com](https://www.pitunnel.com/)
+2. Upgrade to the Standard account (this enables static port numbers for tunnerls; this is necessary as the Pi will reboot as part of the installation, causing the port number to change if static port numbers aren't enabled)
+3. Install PiTunnel on the master Pi - `curl https://pitunnel.com/install/b5KgouUVv | sudo python`
+4. Create a (persistent) tunnel for SSH - `pitunnel --port=22 --name=ssh --persist`
+5. Create a (persistent) tunnel for kubernetes API - `pitunnel --port=6443 --name=k8s --http --persist`
+6. Go to the [PiTunnel dashboard](https://www.pitunnel.com/active) to find the tunnel URLs/ports
 
 ## Deploy from Azure
 
@@ -96,7 +111,7 @@ For detailed instructions on deploying from Azure, including how to setup the se
 For detailed instructions on deploying from Cloud Shell, including how to setup the Cloud Shell environment, see [Consuming: Deploy from Cloud Shell](../../docs/consuming.md#deploy-from-cloud-shell)
 
 
-```porter install --tag cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-177 -d azure```
+```porter install --tag cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-179 -d azure```
 
 
 ## Parameters and Credentials

--- a/porter/pi-k-three-s/README.md
+++ b/porter/pi-k-three-s/README.md
@@ -96,7 +96,7 @@ For detailed instructions on deploying from Azure, including how to setup the se
 For detailed instructions on deploying from Cloud Shell, including how to setup the Cloud Shell environment, see [Consuming: Deploy from Cloud Shell](../../docs/consuming.md#deploy-from-cloud-shell)
 
 
-```porter install --tag cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-174 -d azure```
+```porter install --tag cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-177 -d azure```
 
 
 ## Parameters and Credentials

--- a/porter/pi-k-three-s/azuredeploy-advanced.json
+++ b/porter/pi-k-three-s/azuredeploy-advanced.json
@@ -308,7 +308,7 @@
 								},
 								{
 									"name": "CNAB_BUNDLE_TAG",
-									"value": "cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-177"
+									"value": "cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-179"
 								},
 								{
 									"name": "CNAB_PARAM_master_host",

--- a/porter/pi-k-three-s/azuredeploy-advanced.json
+++ b/porter/pi-k-three-s/azuredeploy-advanced.json
@@ -308,7 +308,7 @@
 								},
 								{
 									"name": "CNAB_BUNDLE_TAG",
-									"value": "cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-174"
+									"value": "cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-177"
 								},
 								{
 									"name": "CNAB_PARAM_master_host",

--- a/porter/pi-k-three-s/azuredeploy-simple.json
+++ b/porter/pi-k-three-s/azuredeploy-simple.json
@@ -102,8 +102,8 @@
 		"cnab_azure_subscription_id": "[subscription().subscriptionId]",
 		"cnab_azure_tenant_id": "[subscription().tenantId]",
 		"cnab_installation_name": "pi-k-three-s",
-		"containerGroupName": "[concat('cg-',uniqueString(resourceGroup().id, 'pi-k-three-s', 'cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-174'))]",
-		"containerName": "[concat('cn-',uniqueString(resourceGroup().id, 'pi-k-three-s', 'cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-174'))]"
+		"containerGroupName": "[concat('cg-',uniqueString(resourceGroup().id, 'pi-k-three-s', 'cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-177'))]",
+		"containerName": "[concat('cn-',uniqueString(resourceGroup().id, 'pi-k-three-s', 'cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-177'))]"
 	},
 	"resources": [
 		{
@@ -207,7 +207,7 @@
 								},
 								{
 									"name": "CNAB_BUNDLE_TAG",
-									"value": "cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-174"
+									"value": "cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-177"
 								},
 								{
 									"name": "CNAB_PARAM_master_host",

--- a/porter/pi-k-three-s/azuredeploy-simple.json
+++ b/porter/pi-k-three-s/azuredeploy-simple.json
@@ -102,8 +102,8 @@
 		"cnab_azure_subscription_id": "[subscription().subscriptionId]",
 		"cnab_azure_tenant_id": "[subscription().tenantId]",
 		"cnab_installation_name": "pi-k-three-s",
-		"containerGroupName": "[concat('cg-',uniqueString(resourceGroup().id, 'pi-k-three-s', 'cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-177'))]",
-		"containerName": "[concat('cn-',uniqueString(resourceGroup().id, 'pi-k-three-s', 'cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-177'))]"
+		"containerGroupName": "[concat('cg-',uniqueString(resourceGroup().id, 'pi-k-three-s', 'cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-179'))]",
+		"containerName": "[concat('cn-',uniqueString(resourceGroup().id, 'pi-k-three-s', 'cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-179'))]"
 	},
 	"resources": [
 		{
@@ -207,7 +207,7 @@
 								},
 								{
 									"name": "CNAB_BUNDLE_TAG",
-									"value": "cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-177"
+									"value": "cnabquickstarts.azurecr.io/porter/pi-k-three-s/bundle:0.1.0-pull-45-merge.1-179"
 								},
 								{
 									"name": "CNAB_PARAM_master_host",

--- a/porter/pi-k-three-s/porter.yaml
+++ b/porter/pi-k-three-s/porter.yaml
@@ -12,18 +12,38 @@ credentials:
     description: Private ssh key for authenticating with all Raspberry Pis
 
 parameters:
-- name: master_ipAddress
+- name: master_internal_IP
   type: string
-  description: "IP address of the master Raspberry Pi node"
+  description: "Internal IP address of the master Raspberry Pi node"
   default: 192.168.0.64
+- name: master_host
+  type: string
+  description: "IP address or DNS name of the master Raspberry Pi node"
+  default: 192.168.0.64
+- name: master_port
+  type: integer
+  description: "SSH port of the master Raspberry Pi node"
+  default: 22
+- name: master_kubernetes_host
+  type: string
+  description: "Host to use in kubeconfig file"
+  default: 192.168.0.64
+- name: master_kubernetes_port
+  type: integer
+  description: "Port to use in kubeconfig file"
+  default: 6443
 - name: master_username
   type: string
   description: "Username for the master Raspberry Pi node"
   default: pi
-- name: workers_ipAddress
+- name: workers_host
   type: string
-  description: "Comma-separated array of IP addresses of the worker Raspberry Pi nodes, e.g. '192.168.0.60,192.168.0.61,192.168.0.62'"
+  description: "Comma-separated array of IP addresses or DNS names of the worker Raspberry Pi nodes, e.g. '192.168.0.60,192.168.0.61,192.168.0.62'"
   default: 192.168.0.66,192.168.0.67,192.168.0.68,192.168.0.69
+- name: workers_port
+  type: string
+  description: "Comma-separated array of ports of the worker Raspberry Pi nodes, e.g. '22,22,22,22'"
+  default: 22,22,22,22
 - name: workers_username
   type: string
   description: "Comma-separated array of usernames for the worker Raspberry Pi nodes, e.g. 'pi,pi,pi'"
@@ -54,9 +74,11 @@ install:
       command: "bash"
       arguments:
         - "enable-container-features.sh"
-        - "{{ bundle.parameters.master_ipAddress }}"
+        - "{{ bundle.parameters.master_host }}"
+        - "{{ bundle.parameters.master_port }}"
         - "{{ bundle.parameters.master_username }}"
-        - "{{ bundle.parameters.workers_ipAddress }}"
+        - "{{ bundle.parameters.workers_host }}"
+        - "{{ bundle.parameters.workers_port }}"
         - "{{ bundle.parameters.workers_username }}"
 
   - exec:
@@ -64,9 +86,12 @@ install:
       command: "bash"
       arguments:
         - "install-k3s.sh"
-        - "{{ bundle.parameters.master_ipAddress }}"
+        - "{{ bundle.parameters.master_internal_IP }}"
+        - "{{ bundle.parameters.master_host }}"
+        - "{{ bundle.parameters.master_port }}"
         - "{{ bundle.parameters.master_username }}"
-        - "{{ bundle.parameters.workers_ipAddress }}"
+        - "{{ bundle.parameters.workers_host }}"
+        - "{{ bundle.parameters.workers_port }}"
         - "{{ bundle.parameters.workers_username }}"
 
   - exec:
@@ -74,8 +99,11 @@ install:
       command: "bash"
       arguments:
         - "get-kubeconfig.sh"
-        - "{{ bundle.parameters.master_ipAddress }}"
+        - "{{ bundle.parameters.master_host }}"
+        - "{{ bundle.parameters.master_port }}"
         - "{{ bundle.parameters.master_username }}"
+        - "{{ bundle.parameters.master_kubernetes_host }}"
+        - "{{ bundle.parameters.master_kubernetes_port }}"
       outputs:
         - name: kubeconfig
           path: /root/.kube/config
@@ -104,9 +132,11 @@ uninstall:
       command: "bash"
       arguments:
         - "disable-container-features.sh"
-        - "{{ bundle.parameters.master_ipAddress }}"
+        - "{{ bundle.parameters.master_host }}"
+        - "{{ bundle.parameters.master_port }}"
         - "{{ bundle.parameters.master_username }}"
-        - "{{ bundle.parameters.workers_ipAddress }}"
+        - "{{ bundle.parameters.workers_host }}"
+        - "{{ bundle.parameters.workers_port }}"
         - "{{ bundle.parameters.workers_username }}"
 
   - exec:
@@ -114,7 +144,9 @@ uninstall:
       command: "bash"
       arguments:
         - "uninstall-k3s.sh"
-        - "{{ bundle.parameters.master_ipAddress }}"
+        - "{{ bundle.parameters.master_host }}"
+        - "{{ bundle.parameters.master_port }}"
         - "{{ bundle.parameters.master_username }}"
-        - "{{ bundle.parameters.workers_ipAddress }}"
+        - "{{ bundle.parameters.workers_host }}"
+        - "{{ bundle.parameters.workers_port }}"
         - "{{ bundle.parameters.workers_username }}"

--- a/porter/pi-k-three-s/scripts/disable-container-features.sh
+++ b/porter/pi-k-three-s/scripts/disable-container-features.sh
@@ -13,7 +13,7 @@ function disableContainerFeatures {
     host=$3
 
     # Enable container features and reboot
-    ssh -o StrictHostKeyChecking=no -J $master_username@$master_host:$master_port $username@$host -p $port /bin/bash << EOF
+    ssh -o StrictHostKeyChecking=no -o ProxyCommand="ssh -o StrictHostKeyChecking=no -W %h:%p $master_username@$master_host -p $master_port" $username@$host -p $port /bin/bash << EOF
 sudo sed -i 's/ cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory//g' /boot/cmdline.txt
 EOF
 }

--- a/porter/pi-k-three-s/scripts/disable-container-features.sh
+++ b/porter/pi-k-three-s/scripts/disable-container-features.sh
@@ -1,30 +1,34 @@
 #!/bin/bash
 
-master_ipAddress=$1
-master_username=$2
-workers_ipAddress=$3
-workers_username=$4
+master_host=$1
+master_port=$2
+master_username=$3
+workers_host=$4
+workers_port=$5
+workers_username=$6
 
 function disableContainerFeatures {
     username=$1
-    ipAddress=$2
+    port=$2
+    host=$3
 
     # Enable container features and reboot
-    ssh -o StrictHostKeyChecking=no $username@$ipAddress /bin/bash << EOF
+    ssh -o StrictHostKeyChecking=no -J $master_username@$master_host:$master_port $username@$host -p $port /bin/bash << EOF
 sudo sed -i 's/ cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory//g' /boot/cmdline.txt
 EOF
 }
 
 # Update master node
 
-disableContainerFeatures $master_username $master_ipAddress
+disableContainerFeatures $master_username $master_port $master_host
 
 # Update worker nodes
 
-IFS=',' read -r -a ipAddresses <<< "$workers_ipAddress"
+IFS=',' read -r -a hosts <<< "$workers_host"
+IFS=',' read -r -a ports <<< "$workers_port"
 IFS=',' read -r -a usernames <<< "$workers_username"
 
-for index in "${!ipAddresses[@]}"
+for index in "${!hosts[@]}"
 do
-    disableContainerFeatures ${usernames[index]} ${ipAddresses[index]}
+    disableContainerFeatures ${usernames[index]} ${ports[index]} ${hosts[index]}
 done

--- a/porter/pi-k-three-s/scripts/enable-container-features.sh
+++ b/porter/pi-k-three-s/scripts/enable-container-features.sh
@@ -13,7 +13,7 @@ function enableContainerFeatures {
     host=$3
 
     # Enable container features and reboot
-    ssh -o StrictHostKeyChecking=no -J $master_username@$master_host:$master_port $username@$host -p $port /bin/bash << EOF
+    ssh -o StrictHostKeyChecking=no -o ProxyCommand="ssh -o StrictHostKeyChecking=no -W %h:%p $master_username@$master_host -p $master_port" $username@$host -p $port /bin/bash << EOF
 sudo sed -i '$ s/$/ cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory/' /boot/cmdline.txt
 sudo reboot
 EOF
@@ -24,12 +24,12 @@ function waitForSsh {
     port=$2
     host=$3
     
-    ssh -o StrictHostKeyChecking=no -J $master_username@$master_host:$master_port $username@$host -p $port echo
+    ssh -o StrictHostKeyChecking=no -o ProxyCommand="ssh -o StrictHostKeyChecking=no -W %h:%p $master_username@$master_host -p $master_port" $username@$host -p $port echo
     while test $? -gt 0
     do
         echo "Waiting for reboot on $host..."
         sleep 5
-        ssh -o StrictHostKeyChecking=no -J $master_username@$master_host:$master_port $username@$host -p $port echo
+        ssh -o StrictHostKeyChecking=no -o ProxyCommand="ssh -o StrictHostKeyChecking=no -W %h:%p $master_username@$master_host -p $master_port" $username@$host -p $port echo
     done
 
     echo "Node at $host started"

--- a/porter/pi-k-three-s/scripts/enable-container-features.sh
+++ b/porter/pi-k-three-s/scripts/enable-container-features.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 
-master_ipAddress=$1
-master_username=$2
-workers_ipAddress=$3
-workers_username=$4
+master_host=$1
+master_port=$2
+master_username=$3
+workers_host=$4
+workers_port=$5
+workers_username=$6
 
 function enableContainerFeatures {
     username=$1
-    ipAddress=$2
+    port=$2
+    host=$3
 
     # Enable container features and reboot
-    ssh -o StrictHostKeyChecking=no $username@$ipAddress /bin/bash << EOF
+    ssh -o StrictHostKeyChecking=no -J $master_username@$master_host:$master_port $username@$host -p $port /bin/bash << EOF
 sudo sed -i '$ s/$/ cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory/' /boot/cmdline.txt
 sudo reboot
 EOF
@@ -18,38 +21,40 @@ EOF
 
 function waitForSsh {
     username=$1
-    ipAddress=$2
+    port=$2
+    host=$3
     
-    ssh -o StrictHostKeyChecking=no $username@$ipAddress echo
+    ssh -o StrictHostKeyChecking=no -J $master_username@$master_host:$master_port $username@$host -p $port echo
     while test $? -gt 0
     do
-        echo "Waiting for reboot on $ipAddress..."
+        echo "Waiting for reboot on $host..."
         sleep 5
-        ssh -o StrictHostKeyChecking=no $username@$ipAddress echo
+        ssh -o StrictHostKeyChecking=no $username@$host -p $port echo
     done
 
-    echo "Node at $ipAddress started"
+    echo "Node at $host started"
 }
 
 # Update master node
 
-enableContainerFeatures $master_username $master_ipAddress
+enableContainerFeatures $master_username $master_port $master_host
 
 # Update worker nodes
 
-IFS=',' read -r -a ipAddresses <<< "$workers_ipAddress"
+IFS=',' read -r -a hosts <<< "$workers_host"
+IFS=',' read -r -a ports <<< "$workers_port"
 IFS=',' read -r -a usernames <<< "$workers_username"
 
-for index in "${!ipAddresses[@]}"
+for index in "${!hosts[@]}"
 do
-    enableContainerFeatures ${usernames[index]} ${ipAddresses[index]}
+    enableContainerFeatures ${usernames[index]} ${ports[index]} ${hosts[index]}
 done
 
 # Wait for nodes to start up again
 
-waitForSsh $master_username $master_ipAddress
+waitForSsh $master_username $master_port $master_host
 
-for index in "${!ipAddresses[@]}"
+for index in "${!hosts[@]}"
 do
-    waitForSsh ${usernames[index]} ${ipAddresses[index]}
+    waitForSsh ${usernames[index]} ${ports[index]} ${hosts[index]}
 done

--- a/porter/pi-k-three-s/scripts/enable-container-features.sh
+++ b/porter/pi-k-three-s/scripts/enable-container-features.sh
@@ -27,7 +27,7 @@ function waitForSsh {
     ssh -o StrictHostKeyChecking=no -o ProxyCommand="ssh -o StrictHostKeyChecking=no -W %h:%p $master_username@$master_host -p $master_port" $username@$host -p $port echo
     while test $? -gt 0
     do
-        echo "Waiting for reboot on $host..."
+        echo "Waiting for reboot on $host:$port..."
         sleep 5
         ssh -o StrictHostKeyChecking=no -o ProxyCommand="ssh -o StrictHostKeyChecking=no -W %h:%p $master_username@$master_host -p $master_port" $username@$host -p $port echo
     done

--- a/porter/pi-k-three-s/scripts/enable-container-features.sh
+++ b/porter/pi-k-three-s/scripts/enable-container-features.sh
@@ -29,7 +29,7 @@ function waitForSsh {
     do
         echo "Waiting for reboot on $host..."
         sleep 5
-        ssh -o StrictHostKeyChecking=no $username@$host -p $port echo
+        ssh -o StrictHostKeyChecking=no -J $master_username@$master_host:$master_port $username@$host -p $port echo
     done
 
     echo "Node at $host started"

--- a/porter/pi-k-three-s/scripts/get-kubeconfig.sh
+++ b/porter/pi-k-three-s/scripts/get-kubeconfig.sh
@@ -1,20 +1,23 @@
 #!/bin/bash
 
-master_ipAddress=$1
-master_username=$2
+master_host=$1
+master_port=$2
+master_username=$3
+master_kubernetes_host=$4
+master_kubernetes_port=$5
 
-ssh -o StrictHostKeyChecking=no $master_username@$master_ipAddress /bin/bash << EOF
+ssh -o StrictHostKeyChecking=no $master_username@$master_host -p $master_port /bin/bash << EOF
 sudo cp /etc/rancher/k3s/k3s.yaml /tmp/config
 sudo chmod 777 /tmp/config
 EOF
 
 mkdir ~/.kube
-scp $master_username@$master_ipAddress:/tmp/config ~/.kube
+scp -P $master_port $master_username@$master_host:/tmp/config ~/.kube
 
-ssh -o StrictHostKeyChecking=no $master_username@$master_ipAddress /bin/bash << EOF
+ssh -o StrictHostKeyChecking=no $master_username@$master_host -p $master_port /bin/bash << EOF
 sudo rm /tmp/config
 EOF
 
-kubectl config set-cluster default --server=https://$master_ipAddress:6443
+kubectl config set-cluster default --server=https://$master_kubernetes_host:$master_kubernetes_port
 kubectl config use-context default
 kubectl config view

--- a/porter/pi-k-three-s/scripts/install-k3s.sh
+++ b/porter/pi-k-three-s/scripts/install-k3s.sh
@@ -46,7 +46,7 @@ do
 
     echo "Installing worker node at $username@$host"
 
-    ssh -o StrictHostKeyChecking=no -J $master_username@$master_host:$master_port $username@$host -p $port /bin/bash << EOF
+    ssh -o StrictHostKeyChecking=no -o ProxyCommand="ssh -o StrictHostKeyChecking=no -W %h:%p $master_username@$master_host -p $master_port" $username@$host -p $port /bin/bash << EOF
 export K3S_URL="https://${master_internal_IP}:6443"
 export K3S_TOKEN="${token}"
 curl -sfL https://get.k3s.io | sh -

--- a/porter/pi-k-three-s/scripts/install-k3s.sh
+++ b/porter/pi-k-three-s/scripts/install-k3s.sh
@@ -44,7 +44,7 @@ do
     port=${ports[index]} 
     host=${hosts[index]}
 
-    echo "Installing worker node at $username@$host"
+    echo "Installing worker node at $username@$host:$port"
 
     ssh -o StrictHostKeyChecking=no -o ProxyCommand="ssh -o StrictHostKeyChecking=no -W %h:%p $master_username@$master_host -p $master_port" $username@$host -p $port /bin/bash << EOF
 export K3S_URL="https://${master_internal_IP}:6443"

--- a/porter/pi-k-three-s/scripts/uninstall-k3s.sh
+++ b/porter/pi-k-three-s/scripts/uninstall-k3s.sh
@@ -30,7 +30,7 @@ do
 
     echo "Uninstalling worker node at $username@$host"
 
-    ssh -o StrictHostKeyChecking=no -J $master_username@$master_host:$master_port $username@$host -p $port /bin/bash << EOF
+    ssh -o StrictHostKeyChecking=no -o ProxyCommand="ssh -o StrictHostKeyChecking=no -W %h:%p $master_username@$master_host -p $master_port" $username@$host -p $port /bin/bash << EOF
 /usr/local/bin/k3s-killall.sh
 /usr/local/bin/k3s-agent-uninstall.sh
 EOF

--- a/porter/pi-k-three-s/scripts/uninstall-k3s.sh
+++ b/porter/pi-k-three-s/scripts/uninstall-k3s.sh
@@ -28,7 +28,7 @@ do
     port=${ports[index]} 
     host=${hosts[index]}
 
-    echo "Uninstalling worker node at $username@$host"
+    echo "Uninstalling worker node at $username@$host:$port"
 
     ssh -o StrictHostKeyChecking=no -o ProxyCommand="ssh -o StrictHostKeyChecking=no -W %h:%p $master_username@$master_host -p $master_port" $username@$host -p $port /bin/bash << EOF
 /usr/local/bin/k3s-killall.sh


### PR DESCRIPTION
- Add ability to set custom SSH ports. 
- Using master node as jumpbox to workers.

These changes are to support the scenarios where users set up a tunnel on the master Pi node and run the bundle from outside their own network.