### PR TITLE
Update READEME.md to clarify only Porter v0 is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Azure CNAB Quickstarts
 
-This repository contains [CNAB](https://cnab.io/) quickstart solutions for deploying cloud-native applications from Azure to either Azure or anywhere at all. CNAB bundles in this repository can be either automatically launched from Azure -- using Azure Container Instances to deploy using [Porter](https://porter.sh) -- or they can be used with Porter anywhere by referencing the `--tag` specified in each bundle directory.
+This repository contains [CNAB](https://cnab.io/) quickstart solutions for deploying cloud-native applications from Azure to either Azure or anywhere at all. CNAB bundles in this repository can be either automatically launched from Azure -- using Azure Container Instances to deploy using [Porter v0](https://v0.getporter.org/docs/) -- or they can be used with Porter anywhere by referencing the `--tag` specified in each bundle directory.
 
-We currently support application bundles built using [Porter](https://porter.sh).
+We currently support application bundles built using [Porter v0](https://v0.getporter.org/docs/). 
 
 The following videos are good resources for getting started with learning about CNAB and Porter:
 


### PR DESCRIPTION
Since the code in this repo has not updated to be compatible with Porter v1, it has become confusing for users to know which version of Porter to use.
This PR updated the README.md to make it clear that only Porter v0 is supported.